### PR TITLE
optimizations to get annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "v-tooltip": "^2.0.1",
     "vue": "^2.6.10",
     "vue-jwt-decode": "^0.1.0",
+    "vue-quill": "^1.5.1",
     "vue-spinners": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "v-tooltip": "^2.0.1",
     "vue": "^2.6.10",
     "vue-jwt-decode": "^0.1.0",
-    "vue-quill": "^1.5.1"
+    "vue-spinners": "^1.0.2"
   }
 }

--- a/src/components/list/ListView.vue
+++ b/src/components/list/ListView.vue
@@ -24,6 +24,11 @@
       </span>
     </div>
     <div class="list-table">
+      <div v-if="totalCount==0">
+        <p>Gathering any class annotations</p>
+        <tile loading="true"></tile>
+      </div>
+
       <list-row
           v-for="thread in sorted"
           :key="thread"
@@ -39,8 +44,12 @@
 </template>
 
 <script>
+import Vue from 'vue'
+import VueSpinners from 'vue-spinners'
 import ListRow from './ListRow.vue'
 import { compare, compareDomPosition } from '../../utils/compare-util.js'
+
+Vue.use(VueSpinners)
 
 /**
  * Component for the list of threads on the side bar.


### PR DESCRIPTION
Added and optimized the backend GET /annotations/new_annotation query to get all head threads + all subsequent child replies. Make changes on the client side to call this new endpoint, so that instead of querying for every single reply, we use the data we are given from this single GET query.