### PR TITLE
Helen/synchronicity playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,14 @@
     "html-to-text": "^5.1.1",
     "moment": "^2.24.0",
     "quill-mention": "^2.1.1",
+    "socket.io": "^3.0.5",
+    "socket.io-client": "^3.0.5",
     "v-tooltip": "^2.0.1",
     "vue": "^2.6.10",
     "vue-jwt-decode": "^0.1.0",
     "vue-quill": "^1.5.1",
-    "vue-spinners": "^1.0.2"
+    "vue-notification": "^1.3.20",
+    "vue-spinners": "^1.0.2",
+    "vue-sweetalert2": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
     "socket.io-client": "^3.0.5",
     "v-tooltip": "^2.0.1",
     "vue": "^2.6.10",
+    "vue-avatar-component": "^1.3.1",
     "vue-jwt-decode": "^0.1.0",
-    "vue-quill": "^1.5.1",
     "vue-notification": "^1.3.20",
+    "vue-quill": "^1.5.1",
     "vue-spinners": "^1.0.2",
     "vue-sweetalert2": "^4.2.0"
   }

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -640,3 +640,7 @@
 .filter-options .hashtags span {
     font-size: 11px;
 }
+
+.typing {
+  margin-left: auto;
+}

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -91,7 +91,16 @@
   background-color: #0069d9;
 }
 
-#nb-app .nb-highlights {
+#nb-app .nb-online{
+  position: absolute;
+  top: 0;
+  right: 395px; /* assuming sidebar is 350px wide + 2 * 10px padding + 5px margin */
+  width: calc(100vw - 395px);
+  height: 100%;
+  pointer-events: none;
+}
+
+#nb-app .nb-highlights{
   position: absolute;
   top: 0;
   right: 395px; /* assuming sidebar is 350px wide + 2 * 10px padding + 5px margin */

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import NbComment from './models/nbcomment.js'
 import { isNodePartOf } from './utils/dom-util.js'
 
 import NbHighlights from './components/highlights/NbHighlights.vue'
+import NbOnline from './components//NbOnline.vue'
 import NbSidebar from './components/NbSidebar.vue'
 import NbNoAccess from './components/NbNoAccess.vue'
 import NbLogin from './components/NbLogin.vue'
@@ -26,7 +27,6 @@ import VueJwtDecode from "vue-jwt-decode";
 import io from "socket.io-client";
 const socket = io("https://127.0.0.1:3000", {reconnect: true});
 
-socket.emit('joined', "Helen")
 
 Vue.use(VueQuill)
 Vue.use(VTooltip)
@@ -138,6 +138,10 @@ function embedNbApp () {
         </div>
         <div v-else>
           <notifications position="top left" group="recentlyAddedThreads" />
+          <nb-online
+            :online-users="onlineUsers"
+            :show-sync-features="showSyncFeatures"> 
+          </nb-online>
           <nb-highlights
             :key="resizeKey"
             :threads="filteredThreads"
@@ -147,6 +151,7 @@ function embedNbApp () {
             :all-class-drafts="allClassDrafts"
             :user-locations="userLocations"
             :show-highlights="showHighlights"
+            :show-sync-features="showSyncFeatures"
             @select-thread="onSelectThread"
             @unselect-thread="onUnselectThread"
             @hover-thread="onHoverThread"
@@ -166,6 +171,7 @@ function embedNbApp () {
             :draft-range="draftRange"
             :show-highlights="showHighlights"
             @switch-class="onSwitchClass"
+            @show-sync-features="onShowSyncFeatures"
             @toggle-highlights="onToggleHighlights"
             @search-option="onSearchOption"
             @search-text="onSearchText"
@@ -229,7 +235,10 @@ function embedNbApp () {
       allUserDraftLocations: {},
       userLocations: {},
       allClassDrafts: [],
-      recentlyAddedThreads: []
+      recentlyAddedThreads: [],
+      showSyncFeatures: true,
+      onlineUsers: [],
+      currentSectionId: ""
     },
     computed: {
       style: function () {
@@ -362,7 +371,7 @@ function embedNbApp () {
         }
 
       },
-      activeClass: async function (newActiveClass) {
+      activeClass: async function (newActiveClass, oldActiveClass) {
         if (newActiveClass != {} && this.user) {
             const source = window.location.origin + window.location.pathname
             const token = localStorage.getItem("nb.user");
@@ -378,8 +387,21 @@ function embedNbApp () {
             .then(res => {
                 this.hashtags = res.data
             })
-            
+
+            axios.get('/api/annotations/myCurrentSection', config)
+            .then (res => {
+              socket.emit('left', {username: this.user.username, classId: oldActiveClass.id, sectionId: this.currentSectionId})
+              this.currentSectionId = res.data
+              console.log("emit join")
+              socket.emit('joined', {username: this.user.username, classId: newActiveClass.id, sectionId: this.currentSectionId})
+            })
             this.getAllAnnotations(source, newActiveClass) // another axios call put into a helper method
+      
+           
+            console.log(oldActiveClass.id)
+            console.log(oldActiveClass)
+
+            
         }
 
       }
@@ -390,6 +412,12 @@ function embedNbApp () {
           const decoded = VueJwtDecode.decode(token)
           this.user = decoded.user
       }
+      socket.on('connections', (data) => {
+        if (data.classId === this.activeClass.id && data.sectionId === this.currentSectionId) {
+          console.log(data.connections)
+          this.onlineUsers = data.connections
+        }
+      })
       socket.on("new_thread", (data) => {
         const source = window.location.origin + window.location.pathname
         let classId = data.classId
@@ -409,6 +437,39 @@ function embedNbApp () {
       socket.on('thread-stop-typing', (id) => {
         this.threads.find(x => x.id === id).typing = false
       });
+
+      socket.on('new_reply', (data) => {
+        console.log(data.id)
+        let thread = this.threads.find(x => x.id === data.id)
+        if (thread.hasMyReplyRequests() && this.showSyncFeatures) {
+          this.$swal({
+
+            title: '',
+
+            text: "A recent comment was added to a thread you requested a reply from. Do you want to open it?",
+
+            type: 'success',
+
+            showCancelButton: true,
+
+            confirmButtonColor: '#3085d6',
+
+            cancelButtonColor: '#d33',
+
+            confirmButtonText: 'Yes, bring me there!',
+            toast: true,
+            position: 'top-start'
+
+          }).then((result) => {
+            if (result.value) {
+              this.onSelectThread(thread)
+            }
+          })   
+        }
+        // console.log(thread)
+
+
+      })
 
       // socket.on('new-draft', (data) => {
       //   if (data.classId === this.activeClass.id) { //TODO: check to make sure another user
@@ -466,6 +527,9 @@ function embedNbApp () {
       },
       recalculateUserLocations: function() {
         // recalculate upon resize
+      },
+      onUserLeft: function() {
+        socket.emit('left', {username: this.user.username, classId: this.activeClass.id, sectionId: this.currentSectionId})
       },
       addSomeAnnotationsBy300(headAnnotations, annotationsData, idx, timer) {
         let newIdx = idx
@@ -744,29 +808,29 @@ function embedNbApp () {
         if (thread.id) { // only if this has an id (we queried it from the server, should we show the notification)
           console.log(window.location.href + `#nb-comment-${thread.id}`)
           
-          this.$swal({
+          // this.$swal({
 
-            title: '',
+          //   title: '',
 
-            text: "A recent comment was added nearby. Do you want to open it?",
+          //   text: "A recent comment was added nearby. Do you want to open it?",
 
-            type: 'success',
+          //   type: 'success',
 
-            showCancelButton: true,
+          //   showCancelButton: true,
 
-            confirmButtonColor: '#3085d6',
+          //   confirmButtonColor: '#3085d6',
 
-            cancelButtonColor: '#d33',
+          //   cancelButtonColor: '#d33',
 
-            confirmButtonText: 'Yes, bring me there!',
-            toast: true,
-            position: 'top-start'
+          //   confirmButtonText: 'Yes, bring me there!',
+          //   toast: true,
+          //   position: 'top-start'
 
-          }).then((result) => {
-            if (result.value) {
-              this.onSelectThread(thread)
-            }
-          })
+          // }).then((result) => {
+          //   if (result.value) {
+          //     this.onSelectThread(thread)
+          //   }
+          // })
           // Vue.notify({
           //   group: 'recentlyAddedThreads',
           //   title: 'A recent comment was added nearby',
@@ -786,14 +850,12 @@ function embedNbApp () {
         this.resizeKey = Date.now()
       },
       onSwitchClass: function(newClass) {
-          console.log('in app switch class');
-          console.log(newClass);
-          
-          
         this.activeClass = newClass
       },
+      onShowSyncFeatures: function(showSyncFeatures) {
+        this.showSyncFeatures = showSyncFeatures
+      },
       onThreadTyping: function(threadId) {
-        // console.log(threadId)
         if (threadId) {
           socket.emit('thread-typing', {threadId: threadId, username: this.user.username})
         }
@@ -837,6 +899,7 @@ function embedNbApp () {
     },
     components: {
       NbHighlights,
+      NbOnline,
       NbSidebar,
       NbLogin,
       NbNoAccess
@@ -888,8 +951,11 @@ function embedNbApp () {
   })
   
   window.addEventListener('resize', e => {
-    // console.log("RESIZINGG")
     app.handleResize()
-    // app.recalculateUserLocations()
   })
+
+  window.onbeforeunload = () => {
+    console.log("unloading and exiting page")
+    app.onUserLeft()
+  }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -392,16 +392,10 @@ function embedNbApp () {
             .then (res => {
               socket.emit('left', {username: this.user.username, classId: oldActiveClass.id, sectionId: this.currentSectionId})
               this.currentSectionId = res.data
-              console.log("emit join")
               socket.emit('joined', {username: this.user.username, classId: newActiveClass.id, sectionId: this.currentSectionId})
             })
             this.getAllAnnotations(source, newActiveClass) // another axios call put into a helper method
-      
-           
-            console.log(oldActiveClass.id)
-            console.log(oldActiveClass)
 
-            
         }
 
       }
@@ -429,14 +423,13 @@ function embedNbApp () {
           }
         }
       })
-      socket.on('thread-typing', (id) => {
-        console.log(id)
-        this.threads.find(x => x.id === id).typing = true
+      socket.on('thread-typing', (data) => {
+        this.threads.find(x => x.id === data.threadId).usersTyping = data.usersTyping
       });
 
-      socket.on('thread-stop-typing', (id) => {
-        this.threads.find(x => x.id === id).typing = false
-      });
+      // socket.on('thread-stop-typing', (id) => {
+      //   this.threads.find(x => x.id === data.threadId).usersTyping = []
+      // });
 
       socket.on('new_reply', (data) => {
         console.log(data.id)
@@ -466,9 +459,6 @@ function embedNbApp () {
             }
           })   
         }
-        // console.log(thread)
-
-
       })
 
       // socket.on('new-draft', (data) => {

--- a/src/app.js
+++ b/src/app.js
@@ -39,11 +39,13 @@ library.add(fas, far)
 
 // axios.defaults.baseURL = 'https://nb2.csail.mit.edu/'
 // axios.defaults.baseURL = 'https://jumana-nb.csail.mit.edu/'
+// axios.defaults.baseURL = 'https://helen-nb.csail.mit.edu/'
 axios.defaults.baseURL = 'https://127.0.0.1:3000/' // for local dev only
 axios.defaults.withCredentials = true
 
 // export const PLUGIN_HOST_URL = 'https://nb2.csail.mit.edu/client'
 // export const PLUGIN_HOST_URL = 'https://jumana-nb.csail.mit.edu/client'
+// export const PLUGIN_HOST_URL = 'https://helen-nb.csail.mit.edu/client'
 export const PLUGIN_HOST_URL = 'https://127.0.0.1:3001' // for local dev only
 
 if (

--- a/src/components/NbChat.vue
+++ b/src/components/NbChat.vue
@@ -1,0 +1,159 @@
+
+<template>
+	<div class="chat">
+		<div v-if="!ready">
+			<button @click="addCurrentUser">Join Chat</button>
+		</div>
+		<div v-if="ready">
+			<h4>My Chat App <span class="float-right">{{connections}} connections</span></h4>
+				<div>
+					<p v-for="user in info" :key=user.username>
+						<i>{{user.username}} {{user.type}}</i>
+					</p>
+				</div>
+				<ul class="list-group list-group-flush text-center">
+					<small v-if="typing" class="text-white">{{typing}} is typing</small>
+					<li v-for="message in messages" :key=message>
+							<span :class="{'float-right':message.type === 0, 'float-left':message.type === 1, 'info-message':message.type === 2}">
+									{{message.message}}
+									<small>{{message.user}}</small>
+							</span>
+					</li>
+				</ul>
+
+				<div class="card-body">
+					<form @submit.prevent="send">
+							<div class="form-group">
+									<input type="text" v-model="newMessage"
+											placeholder="Enter message here">
+							</div>
+					</form>
+				</div>
+		</div>
+	</div>
+
+</template>
+<script>
+import axios from "axios";
+// import io from "socket.io-client";
+
+// const socket = io("https://127.0.0.1:3000", {reconnect: true});
+
+export default {
+	name: "nb-chat",
+	props: {
+    user: Object
+  },
+  data() {
+    return {
+      newMessage: "",
+      messages: [],
+      typing: false,
+      username: null,
+      ready: false,
+      info: [],
+      connections: 0,
+    };
+	},
+	// created() {
+	// 	this.username = this.user.username;
+
+	// 	window.onbeforeunload = () => {
+	// 		alert('leaving')
+	// 		socket.emit('leave', this.username);
+	// 	}
+
+	// 	socket.on('chat-message', (data) => {
+	// 		this.messages.push({
+	// 				message: data.message,
+	// 				type: 1,
+	// 				user: data.user,
+	// 		});
+	// 	});
+
+	// 	socket.on('typing', (data) => {
+	// 		this.typing = data;
+	// 	});
+
+
+	// 	socket.on('stopTyping', () => {
+	// 		this.typing = false;
+	// 	});
+
+	// 	socket.on('joined', (data) => {
+	// 		this.messages.push({
+	// 			message: data + " joined",
+	// 			type: 2,
+	// 			user: ""
+	// 		});
+
+	// 		// setTimeout(() => {
+	// 		// 	this.info = [];
+	// 		// }, 5000);
+	// 	});
+
+	// 	socket.on('leave', (data) => {
+	// 		this.messages.push({
+	// 			message: data + " left",
+	// 			type: 2,
+	// 			user: ""
+	// 		});
+
+	// 			// setTimeout(() => {
+	// 			// 	this.info = [];
+	// 			// }, 5000);
+	// 	});
+
+	// 	socket.on('connections', (data) => {
+	// 			this.connections = data;
+	// 	});
+	// },
+	watch: {
+		newMessage(value) {
+				// value ? socket.emit('typing', this.username) : socket.emit('stopTyping')
+		}
+	},
+  computed: {
+    
+  },
+
+	methods: {
+		send() {
+			this.messages.push({
+				message: this.newMessage,
+				type: 0,
+				user: 'Me',
+			});
+
+			socket.emit('chat-message', {
+				message: this.newMessage,
+				user: this.username
+			});
+			this.newMessage = "";
+		},
+
+		addCurrentUser() {
+			this.ready = true;
+			// socket.emit('joined', this.username)
+		}
+	},
+};
+</script>
+
+<style scoped>
+	.float-right {
+		float: right;
+	}
+
+	.float-left {
+		float: left;
+	}
+
+	.text-center {
+		text-align:center;
+	}
+
+	.info-message {
+		font-style: italic;
+	}
+</style>

--- a/src/components/NbMenu.vue
+++ b/src/components/NbMenu.vue
@@ -4,6 +4,15 @@
         <select v-model="activeClass">
             <option v-for="(item, index) in myClasses" :id="item.id" :value="item">{{item.class_name}}</option>
         </select>
+
+        <label>Show Sync Features</label>
+        <input type="checkbox"
+            v-model="showSyncFeatures"
+            :true-value="true"
+            :false-value="false"
+            @change="onShowSyncFeaturesChange($event)"
+        >
+
     </div>
 </template>
 
@@ -20,6 +29,11 @@ export default {
             default: () => {}
         },
     },
+    data () {
+        return {
+            showSyncFeatures: true
+        }
+    },
     watch: {
         activeClass: function (newClass) {
             this.$emit('switch-class', newClass)
@@ -27,6 +41,11 @@ export default {
     },
     created: function () {
         this.activeClass = this.myClasses[0]
+    },
+    methods: {
+        onShowSyncFeaturesChange: function(event) {
+            this.$emit('show-sync-features', this.showSyncFeatures)
+        }
     }
 }
 </script>

--- a/src/components/NbOnline.vue
+++ b/src/components/NbOnline.vue
@@ -1,55 +1,22 @@
 <template>
-  <svg class="nb-online">
-    <g v-if="showSyncFeatures">
-      <text x="0" y="20" class="small-text">Classmates & Instructors Currently Online: {{numOnlineUsers}}</text>
-
-       <rect
-        v-for="(user, index) in onlineUsers"
+  <div class="nb-online">
+    <div v-if="showSyncFeatures">
+      <h3>Classmates & Instructors Currently Online: {{numOnlineUsers}}</h3>
+      <avatar 
+        v-for="user in onlineUsers"
         :key="user"
-        :x="30 * index + 15*index"
-        :y="40"
-        :height="30"
-        :width="30"
-        style="fill:rgb(179, 236, 255);"
-        >
-      </rect>
-      <text 
-        v-for="(user, index) in onlineUsers"  
-        :key="user"
-        :x="30 * index + 15*index + 10"
-        :y="60"
-        class="heavy-text"
-      >
-      {{user.charAt(0)}}
-      </text>
-
-    </g>
-   
-  </svg>
+        :fullname="user"/>
+    </div>
+  </div>
 </template>
 
 <script>
 
 /**
- * Component for highlight overlays corresponding to threads.
- * Each thread is represented by the head of thread {@link NbComment}.
- *
- * @vue-prop {Array<NbComment>} threads=([]) - all visible threads
- * @vue-prop {NbComment} threadSelected - currently selected thread
- * @vue-prop {Array<NbComment>} threadsHovered=([]) - currently hovered threads
- * @vue-prop {NbRange} draftRange - text range for the new thread currently being drafted
- * @vue-prop {Boolean} showHighlights=true - true if highlights are overlayed
- *   on text, false if collapsed to the side
- *
- * @vue-event {NbComment} select-thread - Emit currently selected thread
- *   when user selects a thread by clicking on the highlight
- * @vue-event {NbComment} hover-thread - Emit the hovered thread
- *   when user starts hovering over the thread's highlight
- * @vue-event {NbComment} unhover-thread - Emit the unhovered thread
- *   when user stops hovering over the thread's highlight
- * @vue-event {null} unselect-thread - Emit when user unselect thread
- *   by clicking outside of highlights
+ * Component for showing who is online overlays corresponding to threads.
  */
+import Avatar from 'vue-avatar-component'
+
 export default {
   name: 'nb-online',
   props: {
@@ -70,7 +37,7 @@ export default {
   mounted: function () {
   },
   components: {
-    
+    Avatar
   }
 }
 </script>

--- a/src/components/NbOnline.vue
+++ b/src/components/NbOnline.vue
@@ -1,0 +1,76 @@
+<template>
+  <svg class="nb-online">
+    <g v-if="showSyncFeatures">
+      <text x="0" y="20" class="small-text">Classmates & Instructors Currently Online: {{numOnlineUsers}}</text>
+
+       <rect
+        v-for="(user, index) in onlineUsers"
+        :key="user"
+        :x="30 * index + 15*index"
+        :y="40"
+        :height="30"
+        :width="30"
+        style="fill:rgb(179, 236, 255);"
+        >
+      </rect>
+      <text 
+        v-for="(user, index) in onlineUsers"  
+        :key="user"
+        :x="30 * index + 15*index + 10"
+        :y="60"
+        class="heavy-text"
+      >
+      {{user.charAt(0)}}
+      </text>
+
+    </g>
+   
+  </svg>
+</template>
+
+<script>
+
+/**
+ * Component for highlight overlays corresponding to threads.
+ * Each thread is represented by the head of thread {@link NbComment}.
+ *
+ * @vue-prop {Array<NbComment>} threads=([]) - all visible threads
+ * @vue-prop {NbComment} threadSelected - currently selected thread
+ * @vue-prop {Array<NbComment>} threadsHovered=([]) - currently hovered threads
+ * @vue-prop {NbRange} draftRange - text range for the new thread currently being drafted
+ * @vue-prop {Boolean} showHighlights=true - true if highlights are overlayed
+ *   on text, false if collapsed to the side
+ *
+ * @vue-event {NbComment} select-thread - Emit currently selected thread
+ *   when user selects a thread by clicking on the highlight
+ * @vue-event {NbComment} hover-thread - Emit the hovered thread
+ *   when user starts hovering over the thread's highlight
+ * @vue-event {NbComment} unhover-thread - Emit the unhovered thread
+ *   when user stops hovering over the thread's highlight
+ * @vue-event {null} unselect-thread - Emit when user unselect thread
+ *   by clicking outside of highlights
+ */
+export default {
+  name: 'nb-online',
+  props: {
+    onlineUsers: {
+      type: Array,
+      default: () => [1, 2, 3]
+    },
+    showSyncFeatures: {
+      type: Boolean,
+      default: true
+    }
+  },
+  computed: {
+    numOnlineUsers: function() {
+      return this.onlineUsers.length
+    }
+  },
+  mounted: function () {
+  },
+  components: {
+    
+  }
+}
+</script>

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -61,8 +61,13 @@
         :hashtags="sortedHashtags"
         @editor-empty="onEditorEmpty"
         @submit-comment="onSubmitComment"
-        @cancel-comment="onCancelComment">
+        @cancel-comment="onCancelComment"
+        @thread-typing="onThreadTyping"
+        @thread-stop-typing="onThreadStopTyping"
+        >
     </editor-view>
+    <!-- <nb-chat :user="user"></nb-chat> -->
+
   </div>
 </template>
 
@@ -78,6 +83,7 @@ import ListView from './list/ListView.vue'
 import ThreadView from './thread/ThreadView.vue'
 import EditorView from './editor/EditorView.vue'
 import NbMenu from './NbMenu.vue'
+import NbChat from './NbChat.vue'
 
 export default {
   name: 'nb-sidebar',
@@ -299,7 +305,6 @@ export default {
         seenByMe: true
       })
       comment.submitAnnotation(this.activeClass.id)
-
       if (this.draftRange) {
         this.$emit('new-thread', comment)
       } else if (this.replyToComment) {
@@ -333,6 +338,16 @@ export default {
       }
       this.editor.initialSettings = Object.assign(defaultSettings, settings)
       this.editor.visible = visible
+    },
+    onThreadTyping: function(val) {
+      if (this.threadSelected) {
+        this.$emit('thread-typing', this.threadSelected.id)
+      }
+    },
+    onThreadStopTyping: function(val) {
+      if (this.threadSelected) {
+        this.$emit('thread-stop-typing', this.threadSelected.id)
+      }
     }
   },
   components: {
@@ -341,7 +356,8 @@ export default {
     ListView,
     ThreadView,
     EditorView,
-    NbMenu
+    NbMenu,
+    NbChat,
   }
 }
 </script>

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -289,8 +289,6 @@ export default {
         return
       }
 
-      let responseWanted = confirm("Do you want to request help from a classmate and get notifications about this thread?")
-
       let comment = new NbComment({
         id: null, // will be updated when submitAnnotation() is called
         range: this.draftRange, // null if this is reply
@@ -304,8 +302,8 @@ export default {
         people: data.mentions.users,
         visibility: data.visibility,
         anonymity: data.anonymity,
-        replyRequestedByMe: data.replyRequested || responseWanted,
-        replyRequestCount: (data.replyRequested || responseWanted) ? 1 : 0,
+        replyRequestedByMe: data.replyRequested,
+        replyRequestCount: data.replyRequested ? 1 : 0,
         upvotedByMe: false,
         upvoteCount: 0,
         seenByMe: true,

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -5,7 +5,8 @@
         <nb-menu 
             :myClasses="myClasses" 
             :activeClass="activeClass"
-            @switch-class="onSwitchClass">
+            @switch-class="onSwitchClass"
+            @show-sync-features="onShowSyncFeatures">
         </nb-menu>
     </div>
     <filter-view
@@ -141,7 +142,7 @@ export default {
           anonymity: CommentAnonymity.IDENTIFIED,
           replyRequested: false
         },
-        isEmpty: true
+        isEmpty: true,
       }
     }
   },
@@ -186,6 +187,9 @@ export default {
   methods: {
     onSwitchClass: function (newClass) {
       this.$emit('switch-class', newClass)
+    },
+    onShowSyncFeatures: function (showSyncFeatures) {
+      this.$emit('show-sync-features', showSyncFeatures)
     },
     onToggleHighlights: function (show) {
       this.$emit('toggle-highlights', show)
@@ -285,6 +289,8 @@ export default {
         return
       }
 
+      let responseWanted = confirm("Do you want to request help from a classmate and get notifications about this thread?")
+
       let comment = new NbComment({
         id: null, // will be updated when submitAnnotation() is called
         range: this.draftRange, // null if this is reply
@@ -298,11 +304,11 @@ export default {
         people: data.mentions.users,
         visibility: data.visibility,
         anonymity: data.anonymity,
-        replyRequestedByMe: data.replyRequested,
-        replyRequestCount: data.replyRequested ? 1 : 0,
+        replyRequestedByMe: data.replyRequested || responseWanted,
+        replyRequestCount: (data.replyRequested || responseWanted) ? 1 : 0,
         upvotedByMe: false,
         upvoteCount: 0,
-        seenByMe: true
+        seenByMe: true,
       })
       comment.submitAnnotation(this.activeClass.id)
       if (this.draftRange) {

--- a/src/components/editor/EditorView.vue
+++ b/src/components/editor/EditorView.vue
@@ -8,7 +8,10 @@
         :initial-content="initialContent"
         :users="users"
         :hashtags="hashtags"
-        @text-change="onTextChange">
+        @text-change="onTextChange"
+        @thread-typing="onThreadTyping"
+        @thread-stop-typing="onThreadStopTyping"
+        >
     </text-editor>
     <div class="footer">
       <div class="selections">
@@ -153,6 +156,12 @@ export default {
     }
   },
   methods: {
+    onThreadStopTyping: function() {
+      this.$emit("thread-stop-typing", true)
+    },
+    onThreadTyping: function() {
+      this.$emit("thread-typing", true)
+    },
     onTextChange: function (html) {
       this.content = html
     },

--- a/src/components/editor/TextEditor.vue
+++ b/src/components/editor/TextEditor.vue
@@ -1,11 +1,17 @@
 <template>
-  <quill
-      v-model="content"
-      output="html"
-      :config="config"
-      @input="onTextChange"
-      @selection-change="onSelectionChange">
-  </quill>
+  <div 
+    @keyup="handleKeyUp" 
+    @keypress="handleKeyPress"
+    tabindex="0"
+  >
+    <quill
+        v-model="content"
+        output="html"
+        :config="config"
+        @input="onTextChange"
+        @selection-change="onSelectionChange">
+    </quill>
+  </div>
 </template>
 
 <script>
@@ -13,7 +19,7 @@ import 'quill-mention'
 import {PLUGIN_HOST_URL} from '../../app' 
 
 let MAX_SUGGEST_USERS = 10
-
+let timer, timeoutVal = 1000;
 /**
  * Component for the base text editor used in comment editor and search bar.
  * Also see {@link NbUser} and {@link NbHashtag}.
@@ -83,7 +89,8 @@ export default {
         bounds: this.bounds,
         theme: 'snow'
       },
-      editor: null
+      editor: null,
+      typing: false
     }
   },
   mounted: function () {
@@ -95,6 +102,21 @@ export default {
     }
   },
   methods: {
+    handleKeyUp: function(e) {
+      console.log("stop typing")
+      window.clearTimeout(timer); // prevent errant multiple timeouts from being generated
+      timer = window.setTimeout(() => {
+        this.typing = false
+        this.$emit("thread-stop-typing", true)
+      }, timeoutVal)
+    },
+    handleKeyPress: function(e) {
+      if (!this.typing) {
+        console.log("typing")
+        this.typing = true
+        this.$emit("thread-typing", true) // only emit if not currently typing
+      }
+    },
     handleMention: function (searchTerm, renderList, mentionChar) {
       let matches = (mentionChar === '@') ? this.users : this.hashtags // mentionChar === "#"
       if (searchTerm.length > 0) {

--- a/src/components/highlights/NbCircle.vue
+++ b/src/components/highlights/NbCircle.vue
@@ -1,0 +1,79 @@
+<template>
+  <g
+      class="nb-circle"
+    >
+    <circle
+        :cx="locationX"
+        :cy="locationY"
+        fill="yellow"
+        opacity="0.3"
+        r="20">
+    </circle>
+  </g>
+</template>
+
+<script>
+// import { getTextBoundingBoxes } from '../../utils/overlay-util.js'
+
+/**
+ * Component for individual highlight overlay corresponding to each thread.
+ * Each thread is represented by the head of thread {@link NbComment}.
+ *
+ * @vue-prop {?NbComment} thread - thread for this highlight,
+ *   null if this is a draft
+ * @vue-prop {NbComment} threadSelected - currently selected thread
+ * @vue-prop {Array<NbComment>} threadsHovered=[] - currently hovered threads
+ * @vue-prop {NbRange} range - text range for this higlight
+ * @vue-prop {Boolean} showHighlights=true - true if highlights are overlayed
+ *   on text, false if collapsed to the side
+ *
+ * @vue-computed {String} style - additional CSS for highlight color
+ *   in case this is a draft, selected, or hovered
+ * @vue-computed {Object} bounds - bounds of highlight
+ * @vue-computed {Array<Rect>} bounds.boxes - bouding box rectangles of the
+ *   text range, calculated by {@link getTextBoundingBoxes}
+ * @vue-computed {Number} bounds.offsetX - x coordinate offset of highlight
+ * @vue-computed {Number} bounds.offsetY - y coordinate offset of highlight
+ * @vue-computed {Boolan} visible - true if this highlight should be overlayed
+ *   on text (i.e. showHighlights is true or this thread is selected)
+ *
+ * @vue-event {NbComment} select-thread - Emit this thread when user clicks on
+ *   this highlight
+ * @vue-event {NbComment} hover-thread - Emit this thread when user starts
+ *   hovering over this highlight
+ * @vue-event {NbComment} unhover-thread - Emit this thread when user stops
+ *   hovering over this highlight
+ */
+export default {
+  name: 'nb-circle',
+  props: {
+    location: {
+      type: Array,
+      default: () => []
+    },
+  },
+  computed: {
+    locationX: function() {
+      // let offsetX = window.pageXOffset ||
+      //   document.documentElement.scrollLeft ||
+      //   document.body.scrollLeft || 0
+      
+      return this.location[0]
+    },
+    locationY: function() {
+      // let offsetY = window.pageYOffset ||
+      //   document.documentElement.scrollTop ||
+      //   document.body.scrollTop || 0
+      // console.log(offsetY)
+      return this.location[1] 
+    }
+  },
+  watch: {
+    /**
+     * When the currently selected thread changes, check if the highlight is
+     * in the view. If not, scroll down/up the window to center the highlight.
+     */
+  },
+
+}
+</script>

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -78,6 +78,39 @@ export default {
     showHighlights: {
       type: Boolean,
       default: true
+    },
+    classDraftBool: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      recent: false
+    }
+  },
+  mounted () {
+    if (this.thread) {
+      const totalTime = 15000
+      let inView = true
+      let rect = this.$el.getBoundingClientRect()
+      let elTop = rect.top
+      let elHeight = rect.height
+      let viewHeight = window.innerHeight
+      if (elTop < 0 || (elTop + elHeight) > viewHeight) { // out of view
+        inView = false
+      }
+      let timeDiff = Date.now() - this.thread.timestamp
+      if (timeDiff < totalTime) {
+        this.recent = true // show blue highlighting for any comments that were recently posted ~
+        if (inView) {
+          this.$emit('new-recent-thread', this.thread) // emit to display notification if in view of current user
+        }
+        setTimeout(() => {
+          console.log("changing back to recent is false")
+          this.recent = false // set back to false after the time diff is over
+        }, totalTime-timeDiff) // we still have 60 seconds - time diff left to display this recent annotation
+      }
     }
   },
   watch: {
@@ -106,8 +139,17 @@ export default {
   },
   computed: {
     style: function () {
+      // if (this.classDraftBool) {
+      //   return 'stroke: rgb(255, 0, 255); stroke-width: 40; '
+      // }
       if (!this.thread) {
         return 'fill: rgb(231, 76, 60); opacity: 0.3;'
+      }
+      if (this.thread.typing) { // if typing, show a pink outline color
+        return 'stroke: rgb(255, 0, 255); stroke-width: 25'
+      }
+      if (this.recent) { // if recently shown, show a cyan outline color
+        return 'stroke: rgb(0, 255, 255); stroke-width: 15'
       }
       if (this.thread === this.threadSelected) {
         return 'fill: rgb(1, 99, 255); opacity: 0.3;'

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -13,7 +13,15 @@
         :y="box.top + bounds.offsetY"
         :height="box.height"
         :width="box.width">
+        <animate
+          v-if="replyRequested && showSyncFeatures"
+          attributeType="XML"
+          attributeName="fill"
+          values="#ffffff;#4a2270ad;#ffffff;#ffffff"
+          dur="0.8s"
+          repeatCount="indefinite"/>
     </rect>
+
   </g>
   <g
       class="nb-highlight"
@@ -82,6 +90,10 @@ export default {
     classDraftBool: {
       type: Boolean,
       default: false
+    },
+    showSyncFeatures: {
+      type: Boolean,
+      default: true
     }
   },
   data () {
@@ -145,10 +157,13 @@ export default {
       if (!this.thread) {
         return 'fill: rgb(231, 76, 60); opacity: 0.3;'
       }
-      if (this.thread.typing) { // if typing, show a pink outline color
+      if (this.thread.typing && this.showSyncFeatures) { // if typing, show a pink outline color
         return 'stroke: rgb(255, 0, 255); stroke-width: 25'
       }
-      if (this.recent) { // if recently shown, show a cyan outline color
+      if (this.thread.replyRequested && this.showSyncFeatures) {
+        return
+      }
+      if (this.recent && this.showSyncFeatures) { // if recently shown, show a cyan outline color
         return 'stroke: rgb(0, 255, 255); stroke-width: 15'
       }
       if (this.thread === this.threadSelected) {
@@ -176,7 +191,13 @@ export default {
     },
     visible: function () {
       return this.showHighlights || (this.thread === this.threadSelected)
-    }
+    },
+    replyRequested: function() {
+      if (this.thread) {
+        return this.thread.hasReplyRequests()
+      }
+      return false
+    },
   },
   methods: {
     onHover: function (state) {

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -157,7 +157,7 @@ export default {
       if (!this.thread) {
         return 'fill: rgb(231, 76, 60); opacity: 0.3;'
       }
-      if (this.thread.typing && this.showSyncFeatures) { // if typing, show a pink outline color
+      if (this.thread.usersTyping && this.thread.usersTyping.length > 0 && this.showSyncFeatures) { // if typing, show a pink outline color
         return 'stroke: rgb(255, 0, 255); stroke-width: 25'
       }
       if (this.thread.replyRequested && this.showSyncFeatures) {

--- a/src/components/highlights/NbHighlights.vue
+++ b/src/components/highlights/NbHighlights.vue
@@ -9,17 +9,31 @@
         :show-highlights="showHighlights"
         @select-thread="$emit('select-thread',thread)"
         @hover-thread="$emit('hover-thread',thread)"
-        @unhover-thread="$emit('unhover-thread',thread)">
+        @unhover-thread="$emit('unhover-thread',thread)"
+        @new-recent-thread="$emit('new-recent-thread', thread)">
     </nb-highlight>
     <nb-highlight
         v-if="draftRange"
         :range="draftRange">
     </nb-highlight>
+    <!-- <nb-highlight
+        v-for="classDraft in allClassDrafts"
+        :key="classDraft"
+        :range="classDraft"
+        :classDraftBool="true">
+    </nb-highlight> -->
+    <nb-circle
+      v-for="userLocation in userLocations"
+      :key="userLocation"
+      :location="userLocation">
+    </nb-circle>
   </svg>
 </template>
 
 <script>
 import NbHighlight from './NbHighlight.vue'
+import NbCircle from './NbCircle.vue'
+
 import { eventsProxyMouse } from '../../utils/highlight-util.js'
 
 /**
@@ -58,13 +72,22 @@ export default {
     showHighlights: {
       type: Boolean,
       default: true
-    }
+    },
+    allClassDrafts: {
+      type: Array,
+      default: () => []
+    },
+    userLocations: {
+      type: Array,
+      default: () => []
+    },
   },
   mounted: function () {
     eventsProxyMouse(document.body, this.$el)
   },
   components: {
-    NbHighlight
+    NbHighlight,
+    NbCircle
   }
 }
 </script>

--- a/src/components/highlights/NbHighlights.vue
+++ b/src/components/highlights/NbHighlights.vue
@@ -7,6 +7,7 @@
         :thread-selected="threadSelected"
         :threads-hovered="threadsHovered"
         :show-highlights="showHighlights"
+        :show-sync-features="showSyncFeatures"
         @select-thread="$emit('select-thread',thread)"
         @hover-thread="$emit('hover-thread',thread)"
         @unhover-thread="$emit('unhover-thread',thread)"
@@ -81,6 +82,10 @@ export default {
       type: Array,
       default: () => []
     },
+    showSyncFeatures: {
+      type: Boolean,
+      default: true
+    }
   },
   mounted: function () {
     eventsProxyMouse(document.body, this.$el)

--- a/src/components/list/ListRow.vue
+++ b/src/components/list/ListRow.vue
@@ -24,9 +24,14 @@
     <span :style="textStyle">
       {{ thread.text }}
     </span>
-    <div v-if="thread.typing" class="typing">
-      <span style="margin:auto;">
-        <i>...</i>
+    <div class="typing">
+      <span>
+        <avatar
+        v-for="user in thread.usersTyping" 
+        :key="user"
+        :fullname="user"
+        :size="18"
+        />
       </span>
     </div>
   </div>
@@ -58,6 +63,9 @@
  * @vue-event {NbComment} unhover-thread - Emit this thread when user stops
  *   hovering over this row
  */
+
+import Avatar from 'vue-avatar-component'
+
 export default {
   name: 'list-view',
   props: {
@@ -118,20 +126,11 @@ export default {
         })
       }
     },
+  },
+  components: {
+    Avatar
   }
 }
 </script>
 
 
-<style scoped>
-.typing {
-    /* background-color: #bbcbda; */
-    background-color: rgb(255, 0, 255, 0.9);
-    color: #aaa;
-    border-radius: 5px;
-    text-align: center;
-    margin-left: auto;
-    padding-left: 5px;
-    padding-right: 3px;
-}
-</style>

--- a/src/components/list/ListRow.vue
+++ b/src/components/list/ListRow.vue
@@ -24,10 +24,16 @@
     <span :style="textStyle">
       {{ thread.text }}
     </span>
+    <div v-if="thread.typing" class="typing">
+      <span style="margin:auto;">
+        <i>...</i>
+      </span>
+    </div>
   </div>
 </template>
 
 <script>
+
 /**
  * Component for each row per thread on the side bar list.
  * Each thread is represented by the head of thread {@link NbComment}.
@@ -60,7 +66,7 @@ export default {
     threadsHovered: {
       type: Array,
       default: () => []
-    }
+    },
   },
   computed: {
     rowStyle: function () {
@@ -111,7 +117,21 @@ export default {
           behavior: 'smooth'
         })
       }
-    }
+    },
   }
 }
 </script>
+
+
+<style scoped>
+.typing {
+    /* background-color: #bbcbda; */
+    background-color: rgb(255, 0, 255, 0.9);
+    color: #aaa;
+    border-radius: 5px;
+    text-align: center;
+    margin-left: auto;
+    padding-left: 5px;
+    padding-right: 3px;
+}
+</style>

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -188,6 +188,8 @@ class NbComment {
      * @type Number
      */
     this.setText()
+    
+    this.typing = false
   }
 
   /**
@@ -209,7 +211,7 @@ class NbComment {
     }
     this.wordCount = this.text.split(' ').length
 
-    this.typing = false
+
   }
 
   /**

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -189,7 +189,7 @@ class NbComment {
      */
     this.setText()
     
-    this.typing = false
+    this.usersTyping = []
   }
 
   /**

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -208,6 +208,8 @@ class NbComment {
       this.text = htmlToText.fromString(this.html, { wordwrap: false })
     }
     this.wordCount = this.text.split(' ').length
+
+    this.typing = false
   }
 
   /**
@@ -265,6 +267,22 @@ class NbComment {
       })
       this.children.sort(compare('timestamp'))
     }
+
+
+
+    // axios.get(`/api/annotations/reply/${this.id}`).then(res => {
+    //   this.children = res.data.map(item => {
+    //     item.parent = this
+    //     return new NbComment(item)
+    //   })
+    //   this.children.sort(compare('timestamp'))
+    // })
+
+
+
+    // axios.get(`/api/annotations/all_reply/${this.id}`).then(res => {
+    //   console.log(res.data)
+    // })
   }
 
   /**


### PR DESCRIPTION
- Only show fetching annotations animation if we are still in the process of fetching (i.e. don't show if there are no annotations for a class)
- Changing the text to "Fetching Annotations" 

![image](https://user-images.githubusercontent.com/8744689/107564423-406c3880-6b97-11eb-9899-7d3bbf00b698.png)

closes https://github.com/haystack/nb/issues/89