### PR TITLE
Don't show the fetching annotations animation if there are no annotations for a class

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -143,6 +143,7 @@ function embedNbApp () {
             :myClasses="myClasses"
             :activeClass="activeClass"
             :hashtags="hashtags"
+            :still-gathering-threads="stillGatheringThreads"
             :total-threads="totalThreads"
             :threads="filteredThreads"
             :thread-selected="threadSelected"
@@ -187,6 +188,7 @@ function embedNbApp () {
       threads: [],
       threadSelected: null,
       threadsHovered: [], // in case of hover on overlapping highlights
+      stillGatheringThreads: true,
       draftRange: null,
       isEditorEmpty: true,
       filter: {
@@ -374,6 +376,7 @@ function embedNbApp () {
         this.user = user
       },
       getAllAnnotations: function (source, newActiveClass) {
+        this.stillGatheringThreads = true
         const token = localStorage.getItem("nb.user");
         const config = { headers: { Authorization: 'Bearer ' + token }, params: { url: source, class: newActiveClass.id } }
 
@@ -392,7 +395,7 @@ function embedNbApp () {
 
               this.threads.push(comment)
             }
-            
+            this.stillGatheringThreads = false
             let link = window.location.hash.match(/^#nb-comment-(.+$)/)
             if (link) {
                 let id = link[1]

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -34,6 +34,7 @@
         :thread-selected="threadSelected"
         :threads-hovered="threadsHovered"
         :show-highlights="showHighlights"
+        :still-gathering-threads="stillGatheringThreads"
         @toggle-highlights="onToggleHighlights"
         @select-thread="onSelectThread"
         @hover-thread="onHoverThread"
@@ -105,6 +106,10 @@ export default {
     totalThreads: { // count of total threads before filter
       type: Number,
       default: 0
+    },
+    stillGatheringThreads: {
+      type: Boolean,
+      default: true
     },
     threads: { // threads after filter
       type: Object,

--- a/src/components/list/ListView.vue
+++ b/src/components/list/ListView.vue
@@ -24,8 +24,8 @@
       </span>
     </div>
     <div class="list-table">
-      <div v-if="totalCount==0">
-        <p>Gathering any class annotations</p>
+      <div v-if="stillGatheringThreads">
+        <p>Fetching Annotations</p>
         <tile loading="true"></tile>
       </div>
 
@@ -96,6 +96,10 @@ export default {
       default: () => []
     },
     showHighlights: {
+      type: Boolean,
+      default: true
+    },
+    stillGatheringThreads: {
       type: Boolean,
       default: true
     }


### PR DESCRIPTION
- Only show fetching annotations animation if we are still in the process of fetching (i.e. don't show if there are no annotations for a class)
- Changing the text to "Fetching Annotations" 

![image](https://user-images.githubusercontent.com/8744689/107564423-406c3880-6b97-11eb-9899-7d3bbf00b698.png)

closes https://github.com/haystack/nb/issues/89