### PR TITLE
Try source paths with query params as well if cannot find source

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -150,6 +150,7 @@ function embedNbApp () {
             :threads-hovered="threadsHovered"
             :draft-range="draftRange"
             :show-highlights="showHighlights"
+            :source-url="sourceURL"
             @switch-class="onSwitchClass"
             @toggle-highlights="onToggleHighlights"
             @search-option="onSearchOption"
@@ -209,7 +210,8 @@ function embedNbApp () {
         minUpvotes: 0
       },
       showHighlights: true,
-      resizeKey: Date.now() // work around to force redraw highlights
+      resizeKey: Date.now(), // work around to force redraw highlights,
+      sourceURL: '',
     },
     computed: {
       style: function () {
@@ -336,15 +338,31 @@ function embedNbApp () {
             if (this.myClasses.length === 1) {
                 this.activeClass = this.myClasses[0]
             }
+            this.sourceURL = source 
 
         } else {
-            console.log("Sorry you don't have access");
-        }
+          const sourceWithQuery = window.location.href // try the source with query params as well
+          const configWithQuery = { headers: { Authorization: 'Bearer ' + token }, params: { url: sourceWithQuery }}
+          const myClassesWithQuery = await axios.get('/api/annotations/myClasses', configWithQuery)
+          if (myClassesWithQuery.data.length > 0) {
+            this.myClasses = myClassesWithQuery.data
 
+            if (this.myClasses.length === 1) {
+                this.activeClass = this.myClasses[0]
+            }
+            this.sourceURL = sourceWithQuery
+
+          } else { 
+            console.log("Sorry you don't have access");
+          } 
+        }
       },
       activeClass: async function (newActiveClass) {
         if (newActiveClass != {} && this.user) {
-            const source = window.location.origin + window.location.pathname
+            let source = window.location.origin + window.location.pathname
+            if (this.sourceURL.length > 0) {
+              source = this.sourceURL
+            }
             const token = localStorage.getItem("nb.user");
             const config = { headers: { Authorization: 'Bearer ' + token }, params: { url: source, class: newActiveClass.id } }
 

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -124,6 +124,10 @@ export default {
     showHighlights: {
       type: Boolean,
       default: true
+    },
+    sourceUrl: {
+      type: String,
+      default: ""
     }
   },
   data () {
@@ -303,7 +307,8 @@ export default {
         upvoteCount: 0,
         seenByMe: true
       })
-      comment.submitAnnotation(this.activeClass.id)
+      let source = this.sourceUrl.length > 0 ? this.sourceUrl : window.location.href.split('?')[0]
+      comment.submitAnnotation(this.activeClass.id, source)
 
       if (this.draftRange) {
         this.$emit('new-thread', comment)

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -215,12 +215,12 @@ class NbComment {
    * On success, set {@link NbComment#id}. If this is a thread head,
    * {@link NbComment#loadReplies} will be called to also load replies.
    */
-  submitAnnotation (classId) {
+  submitAnnotation (classId, sourceUrl) {
     const token = localStorage.getItem("nb.user");
     const headers = { headers: { Authorization: 'Bearer ' + token }}
     if (!this.parent) {
       return axios.post('/api/annotations/annotation', {
-        url: window.location.href.split('?')[0],
+        url: sourceUrl,
         class: classId,
         content: this.html,
         range: this.range.serialize(),


### PR DESCRIPTION
Currently, we just try to identify a sourc with the window.location.pathname (without any query params).

Add a fix so that if we cannot identify a source with the pathname, use the entire window.location.href (which includes query params). This will be useful for when we try to load the nb viewer for pdf documents (https://github.com/lihelennn/nb/tree/helen/pdf-to-html)

NOTE: MERGE BEFORE https://github.com/haystack/nb/pull/124