### PR TITLE
Fetching annotations small fix

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -678,6 +678,7 @@ function embedNbApp () {
               this.notificationThreads[i].comment = comment // replace comment for existing notifications referring to old version of comment
             }
           })
+
           this.threads.push(comment)
         })
       },
@@ -702,7 +703,6 @@ function embedNbApp () {
           }).then((result) => {
             if (result.value) {
               this.swalClicked = true 
-              notification.setIsUnseen(false)
               this.onSelectNotification(notification)
             }
           }) 
@@ -957,13 +957,13 @@ function embedNbApp () {
         if (this.threadSelected) {
           socket.emit('thread-stop-typing', {threadId: this.threadSelected.id, username: this.user.username}) // selecting new thread so stop typing on this thread
         }
-        this.threadSelected = thread
         if (thread.associatedNotification !== null) {
           thread.associatedNotification.setIsUnseen(false)
         }
+        this.threadSelected = thread
         thread.markSeenAll()
       },
-      onSelectNotification: function (notification) {        
+      onSelectNotification: function (notification) {  
         this.notificationSelected = notification
         notification.setIsUnseen(false)
         this.onSelectThread(notification.comment)
@@ -975,20 +975,17 @@ function embedNbApp () {
         if (this.swalClicked) {
           this.swalClicked = false // don't unselect if this was a popup notification click
         } else { // otherwise, it was a valid unselect thread click
-          this.threadSelected = null
+          if (!this.isInnotationHover) {
+            this.threadSelected = null
+          }
           if (this.draftRange && this.isEditorEmpty) {
             this.onCancelDraft()
           }
         }
-        
+    
         this.threadViewInitiator = 'NONE'
         console.log('threadViewInitiator: ' + this.threadViewInitiator)
-        if (!this.isInnotationHover) {
-          this.threadSelected = null
-        }
-        if (this.draftRange && this.isEditorEmpty) {
-          this.onCancelDraft()
-        }
+
       },
       onHoverThread: function (thread) {
         // console.log('onHoverThread in app')

--- a/src/components/NbOnline.vue
+++ b/src/components/NbOnline.vue
@@ -135,11 +135,11 @@ export default {
     },
     getTooltipContent: function () {
       return `<div>
-        <span><label>blinking thread: </label>thread has recent typing or new post activity</span>
+        <span><label>blinking thread: </label>comment has recent typing or new post activity</span>
         <br><br>
-        <span><label style="background-color: rgb(255, 0, 255);">pink:</label> someone needs a reply request</span>
+        <span><label style="background-color: rgb(255, 0, 255);">pink: </label>comment has a reply request</span>
         <br><br>
-        <span><label style="background-color: rgba(80, 54, 255, 0.9);">purple:</label> thread has notification associated</span>
+        <span><label style="background-color: rgba(80, 54, 255, 0.9);">purple: </label>comment has notification associated</span>
       </div>`
     }
   },

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -313,20 +313,24 @@ export default {
       }
       let content = ""
       if (this.isRecentThread || this.isTypingThread) {
-        content = "recently commented: "
+        content = "<span>recent comment:</span>"
       } else if (this.notificationThread) {
-        content = this.thread.associatedNotification.readableType + " notification: "
+        content = "<span>" + 
+          this.thread.associatedNotification.readableType + " notification:</span>"
       } else if (this.replyRequestThread) {
-        content = "reply requested: "
+        content = "<span>reply requested comment:</span>"
       } else {
         return "" // no associated notification, return empty string
       }
-      let text = this.thread.text 
-      if (this.notificationThread && this.thread.associatedNotification.specificAnnotation !== null) {
-        text = this.thread.associatedNotification.specificAnnotation.text
-      }
-      content += text.substring(0, 20)
-      if (text.length > 20) {
+      content += "<br>"
+
+      let relevantComment = 
+        (this.notificationThread && this.thread.associatedNotification.specificAnnotation !== null) 
+          ? this.thread.associatedNotification.specificAnnotation : this.thread 
+
+      let text = relevantComment.text
+      content += text.substring(0, 30)
+      if (text.length > 30) {
         content += "..."
       }
       return content

--- a/src/components/list/ListRow.vue
+++ b/src/components/list/ListRow.vue
@@ -22,11 +22,15 @@
             <div class="icon-wrapper counter" :style="counterStyle">
                 {{ thread.countAllReplies() + 1 }}
             </div>
-            <div v-if="thread.hasInstructorPost()" class="icon-wrapper instr">
+            <div v-if="thread.hasInstructorPost()" 
+              v-tooltip="'This comment has an instructor comment'"
+              class="icon-wrapper instr">
                 i
             </div>
             <div v-else class="placeholder instr"></div>
-            <div v-if="thread.hasReplyRequests()" class="icon-wrapper question"
+            <div v-if="thread.hasReplyRequests()" 
+              v-tooltip="'This comment has a reply request'"
+              class="icon-wrapper question"
                 :style="iconStyle">
                 <font-awesome-icon icon="question">
                 </font-awesome-icon>

--- a/src/components/list/ListView.vue
+++ b/src/components/list/ListView.vue
@@ -34,8 +34,8 @@
         </span>
       </div>
       <div class="list-table">
-        <div v-if="totalCount==0">
-          <p>Gathering any class annotations</p>
+        <div v-if="stillGatheringThreads">
+          <p>Fetching Annotations</p>
           <tile loading="true"></tile>
         </div>
 

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -555,6 +555,56 @@ class NbComment {
     return null
   }
 
+  getMostRecentPost () {
+    let mostRecentThread = this
+    for (let child of this.children) {
+      let childMostRecentThread = child.getMostRecentPost()
+      if (childMostRecentThread.timestamp > mostRecentThread.timestamp) {
+        mostRecentThread = childMostRecentThread
+      }
+    }
+    return mostRecentThread
+  }
+
+  getInstructorPost () {
+    if (this.instructor && !this.seenByMe) { return this } // if unseen and is instructor post, return
+    for (let child of this.children) {
+      let res = child.getInstructorPost()
+      if (res !== null) {
+        return res
+      }
+    }
+    return null
+  }
+
+  getUserTagPost (userID) {
+    if (this.people.includes(userID) && !this.seenByMe) { // if unseen and comment has user tag with userID
+      return this
+    }
+    for (let child of this.children) {
+      let res = child.getUserTagPost(userID)
+      if (res !== null) {
+        return res
+      }
+    }
+    return null
+  }
+
+  getReplyRequestResponsePost (userID) { // if unseen comment and is responding to a reply request by a userID
+    if (!this.seenByMe && this.parent !== null) {
+      if (this.parent.author === userID && this.parent.replyRequestedByMe) {
+        return this
+      }
+    }
+    for (let child of this.children) {
+      let res = child.getReplyRequestResponsePost(userID)
+      if (res !== null) {
+        return res
+      }
+    }
+    return null
+  }
+
   /**
    * Mark this comment and all its descendants as seen by the current user.
    */


### PR DESCRIPTION
- `synchronous` branch showed the fetching annotations animation even if there were no annotations posted yet. this change makes sure the annotation is no longer shown when the annotations are done being fetched.
- make sure that clicking a popup notification selects and shows the thread
- for notifications related to replies (not new threads), make sure to sure the notification has the correct associated comment by searching for the correct child comment
- implement tooltip feedback from haystack group meeting

https://helen-nb.csail.mit.edu/nb_viewer.html?id=76f3911451bc89900db7c3acad3b7648