### PR TITLE
Link functionality for comments/annotations

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -19,7 +19,7 @@
           <div class="overflow-options">
             <div
                 class="overflow-option"
-                @click="$emit('logout')">
+                @click="$emit('logouts')">
               Logout
             </div>
           </div>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -19,7 +19,7 @@
           <div class="overflow-options">
             <div
                 class="overflow-option"
-                @click="$emit('logouts')">
+                @click="$emit('logout')">
               Logout
             </div>
           </div>

--- a/src/components/editor/EditorView.vue
+++ b/src/components/editor/EditorView.vue
@@ -120,6 +120,7 @@ export default {
         [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
         [ 'bold', 'italic', 'underline', 'strike' ],
         [{ 'script': 'super' }, { 'script': 'sub' } ],
+        ['link'],
         // [ 'blockquote', 'code-block', 'link'/*, 'formula'*/ ],
         // [{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'indent': '-1' }, { 'indent': '+1' }],
         // [{ 'align': [] }],


### PR DESCRIPTION
Issue #112 from nb
Link functionality in comments now supported 

- Frontend: Added quill toolbar built-in link function (found that attempting to use other methods was less efficient) 

Notes: 
- Does not automatically format links if just pasting one in, need to highlight and apply link functionality, same way one would highlight text and apply the bold functionality (demonstrated in screenshots) 
- Able to add in both new comments and replies
- Has edit functionality after formatting a link
- Clicking the link while editing a comment pops up another link, but when clicking a submitted link in a submitted comment it goes directly to site (no other pop up) 

![Added link icon in tool bar](https://user-images.githubusercontent.com/35709638/123021537-42929f00-d3a2-11eb-8e54-232d394c4ae2.PNG)

![Adding a link to text](https://user-images.githubusercontent.com/35709638/123022235-8043f780-d3a3-11eb-847b-eac7537d2104.PNG)

![Does not automatically format pasted links but automatically fills after applying link function](https://user-images.githubusercontent.com/35709638/123022446-cef19180-d3a3-11eb-8cc5-1c6ad3d01f44.PNG)

![Clicking on generates clickable link, also has edit option on right](https://user-images.githubusercontent.com/35709638/123022512-e6c91580-d3a3-11eb-8695-db51cd4afce4.PNG)

![Displays in submitted comments and is directly clickable here](https://user-images.githubusercontent.com/35709638/123022530-ef215080-d3a3-11eb-90a0-0e200e82c4a0.PNG)


