### PR TITLE
Helen/notify only recent replies comments

### DIFF
--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -475,8 +475,8 @@
   display: flex;
 }
 .icon-wrapper.tag {
-  background-color: #4d4d4d;
-  color: #fff;
+  /* background-color: #4d4d4d;
+  color: #fff; */
   font-size: 14px;
   font-family: 'Verdana', 'Geneva', sans-serif;
   height: 16px;
@@ -493,8 +493,8 @@
   border-radius: 3px;
 }
 .icon-wrapper.reply-request {
-  background-color: #cc0088;
-  color: #fff;
+  /* background-color: #cc0088;
+  color: #fff; */
   font-size: 14px;
   font-family: 'Verdana', 'Geneva', sans-serif;
   height: 16px;

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -367,6 +367,9 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+#nb-app .nb-sidebar .list-view .list-row #notification-row-flags{ /*only for notification row style*/
+  justify-content: flex-start;
+}
 #nb-app .nb-sidebar .list-view .list-row:nth-child(even) {
   background-color: #f0f0f0;
 }
@@ -499,8 +502,17 @@
   border-radius: 3px;
 }
 .icon-wrapper.recent {
-  background-color: #009999;
-  color: #fff;
+  /* background-color: #009999;
+  color: #fff; */
+  font-size: 14px;
+  font-family: 'Verdana', 'Geneva', sans-serif;
+  height: 16px;
+  padding: 0 3px;
+  border-radius: 3px;
+}
+.icon-wrapper.reply {
+  /* background-color: #009999;
+  color: #fff; */
   font-size: 14px;
   font-family: 'Verdana', 'Geneva', sans-serif;
   height: 16px;

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -1251,3 +1251,20 @@ nb-innotation-controller {
   background-color: #d57d80;
 }
 
+#olderNotificationHeading {
+  width: 100%; 
+  text-align: center; 
+  border-bottom: 1px solid #000; 
+  line-height: 0.1em;
+  margin: 15px 0 15px;
+}
+
+#olderNotificationSpanWhite { 
+  background:#fff; 
+  padding:0 10px; 
+}
+
+#olderNotificationSpanGray { 
+  background:rgb(228, 228, 228);
+  padding:0 10px; 
+}

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -1233,6 +1233,7 @@ nb-innotation-controller {
 .icons-left {
   margin-top: 3px;
   margin-left: auto;
+  margin-right: 10px;
 }
 
 .vdr {

--- a/src/app.js
+++ b/src/app.js
@@ -197,6 +197,7 @@ function embedNbApp() {
                     @hover-thread="onHoverThread"
                     @unhover-thread="onUnhoverThread"
                     @toggle-mute-notifications="onToggleMuteNotifications"
+                    @dock-draggable-notifications="onDockDraggableNotifications"
                     @close-draggable-notications="onCloseDraggableNotifications">
                 </nb-notification-sidebar>
                 <nb-sidebar
@@ -230,8 +231,10 @@ function embedNbApp() {
                     @switch-class="onSwitchClass"
                     @show-sync-features="onShowSyncFeatures"
                     @toggle-mute-notifications="onToggleMuteNotifications"
+                    @undock-draggable-notifications="onUndockDraggableNotifications"
                     @open-draggable-notifications="onOpenDraggableNotifications"
                     @open-sidebar-notifications="onOpenSidebarNotifications"
+                    @close-sidebar-notifications="onCloseSidebarNotifications"
                     @toggle-highlights="onToggleHighlights"
                     @search-option="onSearchOption"
                     @search-text="onSearchText"
@@ -1204,8 +1207,19 @@ function embedNbApp() {
             onCloseDraggableNotifications: function () {
                 this.draggableNotificationsOpened = false;
             },
+            onDockDraggableNotifications: function () {
+                this.draggableNotificationsOpened = false;
+                this.sidebarNotificationsOpened = true;
+            },
+            onUndockDraggableNotifications: function () {
+                this.draggableNotificationsOpened = true;
+                this.sidebarNotificationsOpened = false;
+            },
             onOpenDraggableNotifications: function () {
                 this.draggableNotificationsOpened = true;
+            },
+            onCloseSidebarNotifications: function () {
+                this.sidebarNotificationsOpened = false;
             },
             onOpenSidebarNotifications: function () {
                 this.sidebarNotificationsOpened = true;

--- a/src/app.js
+++ b/src/app.js
@@ -706,9 +706,9 @@ function embedNbApp() {
                         // set any type of notification
                         let notification = null
                         if (specificAnnotation && specificAnnotation.parent && specificAnnotation.parent.author === this.user.id) { // if this new comment is a reply to the user
-                          notification = new NbNotification(comment, "reply", false, specificAnnotation)
+                          notification = new NbNotification(comment, "reply", false, specificAnnotation, false)
                         } else if (this.user.role === 'instructor' && isNewThread) { // instructors will get all new threads and posts
-                          notification = new NbNotification(comment, "recent", false, specificAnnotation)
+                          notification = new NbNotification(comment, "recent", false, specificAnnotation, false)
                         }
                         // if (taggedUsers.includes(this.user.id)) { // user tagged in post
                         //     notification = new NbNotification(comment, "tag", true, specificAnnotation)
@@ -777,7 +777,7 @@ function embedNbApp() {
                     }, 30000)
                 }
             },
-            newNotification: function (comment) {
+            newOfflineNotification: function (comment) {
                 // if (this.notificationThreads.length < 5) { // limit to 5 initial notifications
                 //     let taggedComment = comment.getUserTagPost(this.user.id)
                 //     if (taggedComment !== null) {
@@ -796,7 +796,7 @@ function embedNbApp() {
                 // }
                 let unreadReply = comment.hasMyAuthorReplies(this.user.id)
                 if (unreadReply) { // if thread has unseen comments that reply to this author
-                  return new NbNotification(comment, "reply", false, unreadReply)
+                  return new NbNotification(comment, "reply", false, unreadReply, true)
                 }
                 return null
             },
@@ -819,10 +819,10 @@ function embedNbApp() {
                             // Nb Comment
                             let comment = new NbComment(item, res.data.annotationsData)
                             this.threads.push(comment)
-                            let newNotification = this.newNotification(comment) // Either get back a notification to add or null
-                            if (newNotification !== null) {
-                                this.notificationThreads.push(newNotification)
-                                comment.associatedNotification = newNotification
+                            let offlineNotification = this.newOfflineNotification(comment) // Either get back a notification to add or null
+                            if (offlineNotification !== null) {
+                                this.notificationThreads.push(offlineNotification)
+                                comment.associatedNotification = offlineNotification
                             }
                         }
 
@@ -1148,7 +1148,7 @@ function embedNbApp() {
             onNewRecentThread: function (thread) {
                 let mostRecentThread = thread.getMostRecentPost() // get the most recent thread to see if we should notify about it
                 if (mostRecentThread.author !== this.user.id && thread.associatedNotification === null) { // if not this author and no notifications for this thread yet
-                    let notification = new NbNotification(thread, "recent", false, mostRecentThread) // associated annotation is the most recent one
+                    let notification = new NbNotification(thread, "recent", false, mostRecentThread, false) // associated annotation is the most recent one
                     this.notificationThreads.push(notification)
                     thread.associatedNotification = notification
                 }

--- a/src/components/NbNotificationSidebar.vue
+++ b/src/components/NbNotificationSidebar.vue
@@ -23,6 +23,7 @@
           @hover-thread="onHoverThread"
           @unhover-thread="onUnhoverThread"
           @toggle-mute-notifications="onToggleMuteNotifications"
+          @dock-draggable-notifications="$emit('dock-draggable-notifications')"
           @close-draggable-notications="$emit('close-draggable-notications')"
       >
       </notification-sidebar-view>

--- a/src/components/NbOnline.vue
+++ b/src/components/NbOnline.vue
@@ -43,12 +43,12 @@
         @hide="showOverflow = false">
         <span
             class="tooltip-target overflow-icon"
-            @click="showOverflow = true">
-          <font-awesome-icon icon="envelope-open" class="icon">
-          </font-awesome-icon>   
+            @click="onOpenSidebarNotifications"
+        >
+          <font-awesome-icon icon="envelope-open" class="icon"></font-awesome-icon>   
           {{ numberNotificationsUnseen }}               
         </span>
-        <template slot="popover">
+        <!-- <template slot="popover">
           <div class="overflow-options">
             <div
               class="overflow-option"
@@ -63,7 +63,7 @@
               Open in sidebar
             </div>
           </div>
-        </template>
+        </template> -->
       </v-popover>
     </div>
 

--- a/src/components/NbSidebar.vue
+++ b/src/components/NbSidebar.vue
@@ -76,7 +76,9 @@
             @hover-thread="onHoverThread"
             @unhover-thread="onUnhoverThread"
             @toggle-mute-notifications="onToggleMuteNotifications"
-            @open-draggable-notifications="onOpenDraggableNotifications">
+            @undock-draggable-notifications="onUndockDraggableNotifications"
+            @close-sidebar-notifications="onCloseSidebarNotifications"
+        >
         </notification-view>
         <thread-view
             v-if="threadSelected"
@@ -500,11 +502,17 @@ export default {
         onToggleMuteNotifications: function () {
             this.$emit('toggle-mute-notifications')
         },
+        onUndockDraggableNotifications: function () {
+            this.$emit('undock-draggable-notifications')
+        },
         onOpenDraggableNotifications: function () {
             this.$emit('open-draggable-notifications')
         },
         onOpenSidebarNotifications: function () {
             this.$emit('open-sidebar-notifications')
+        },
+        onCloseSidebarNotifications: function () {
+            this.$emit('close-sidebar-notifications')
         },
         onLogExpSpotlight: async function (event = 'NONE', initiator = 'NONE', type = 'NONE', highQuality = false, annotationId = null, annotation_replies_count = 0) {
             this.$emit('log-exp-spotlight', event, initiator, type, highQuality, annotationId, annotation_replies_count)

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -126,10 +126,7 @@ export default {
             let elTop = rect.top
             let elHeight = rect.height
             let viewHeight = window.innerHeight
-            if (elTop < 0 || (elTop + elHeight) > viewHeight) { // out of view
-                console.log(this.thread)
-                console.log(elTop)
-                console.log("\n")
+            if ((elTop + elHeight) > viewHeight) { // past the user's location (true if before the user location)
                 inView = false
             }
             let timeDiff = Date.now() - this.thread.getMostRecentTimeStamp()

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -127,6 +127,9 @@ export default {
             let elHeight = rect.height
             let viewHeight = window.innerHeight
             if (elTop < 0 || (elTop + elHeight) > viewHeight) { // out of view
+                console.log(this.thread)
+                console.log(elTop)
+                console.log("\n")
                 inView = false
             }
             let timeDiff = Date.now() - this.thread.getMostRecentTimeStamp()
@@ -181,7 +184,7 @@ export default {
                 // return 'stroke: rgb(0, 255, 255); stroke-width: 15'
                 return
             }
-            if (this.notificationThread) {
+            if (this.unseenNotificationThread) {
                 return 'fill: rgb(80, 54, 255); opacity: 0.7;'
                 // return 'stroke: rgb(80, 54, 255); stroke-width: 8; stroke-opacity: 0.2;'
             }
@@ -217,8 +220,8 @@ export default {
         replyRequestThread: function () {
             return this.showSyncFeatures && this.thread && this.thread.hasReplyRequests()
         },
-        notificationThread: function () {
-            return this.thread && this.thread.associatedNotification !== null && this.showSyncFeatures
+        unseenNotificationThread: function () {
+            return this.thread && this.thread.associatedNotification !== null && this.showSyncFeatures && this.thread.associatedNotification.unseen
         },
         bounds: function () {
             let bounds = {}
@@ -274,11 +277,11 @@ export default {
             }
         },
         logSyncClick: function () {
-            if (this.notificationThread || this.isTypingThread || this.isRecentThread || this.showTypingActivityAnimation) {
+            if (this.unseenNotificationThread || this.isTypingThread || this.isRecentThread || this.showTypingActivityAnimation) {
                 let trigger_type = ''
                 if (this.isTypingThread || this.isRecentThread) {
                     trigger_type = 'USER_SAW_RECENT_ACTIVITY'
-                } else if (this.notificationThread) {
+                } else if (this.unseenNotificationThread) {
                     trigger_type = this.thread.associatedNotification.trigger 
                 } else {
                     trigger_type = 'REPLY_REQUESTED'
@@ -305,7 +308,7 @@ export default {
             let content = ""
             if (this.isRecentThread || this.isTypingThread) {
                 content = "<span>recent comment:</span>"
-            } else if (this.notificationThread) {
+            } else if (this.unseenNotificationThread) {
                 content = "<span>" + 
                 this.thread.associatedNotification.readableType + " notification:</span>"
             } else if (this.replyRequestThread) {
@@ -316,7 +319,7 @@ export default {
             content += "<br>"
 
             let relevantComment = 
-                (this.notificationThread && this.thread.associatedNotification.specificAnnotation !== null) 
+                (this.unseenNotificationThread && this.thread.associatedNotification.specificAnnotation !== null) 
                 ? this.thread.associatedNotification.specificAnnotation : this.thread 
 
             let text = relevantComment.text

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -17,7 +17,7 @@
             :y="box.top + bounds.offsetY"
             :height="box.height"
             :width="box.width">
-            <animate
+            <!-- <animate
                 v-if="showRecentActivityAnimation"
                 attributeType="XML"
                 attributeName="fill"
@@ -30,7 +30,7 @@
                 attributeName="fill"
                 values="#ffffff;#4a2270D9;#ffffff;#ffffff"
                 dur="2.0s"
-                repeatCount="indefinite"/>
+                repeatCount="indefinite"/> -->
         </rect>
 
     </g>
@@ -185,15 +185,15 @@ export default {
                 return 'fill: rgb(80, 54, 255); opacity: 0.7;'
                 // return 'stroke: rgb(80, 54, 255); stroke-width: 8; stroke-opacity: 0.2;'
             }
-            if (this.replyRequestThread) {
-                if (this.thread.isUnseen() && this.currentConfigs.isShowIndicatorForUnseenThread) {
-                    // return 'stroke: rgb(255, 0, 255); stroke-width: 8; stroke-opacity: 0.25;'
-                    return 'fill: rgb(255, 0, 255); opacity: 1.0;'
-                } else {
-                    // return 'stroke: rgb(255, 0, 255); stroke-width: 8; stroke-opacity: 0.10;'
-                    return 'fill: rgb(255, 0, 255); opacity: 0.5;'
-                }
-            }
+            // if (this.replyRequestThread) {
+            //     if (this.thread.isUnseen() && this.currentConfigs.isShowIndicatorForUnseenThread) {
+            //         // return 'stroke: rgb(255, 0, 255); stroke-width: 8; stroke-opacity: 0.25;'
+            //         return 'fill: rgb(255, 0, 255); opacity: 1.0;'
+            //     } else {
+            //         // return 'stroke: rgb(255, 0, 255); stroke-width: 8; stroke-opacity: 0.10;'
+            //         return 'fill: rgb(255, 0, 255); opacity: 0.5;'
+            //     }
+            // }
             return null
         },
         isRecentThread: function () {

--- a/src/components/highlights/NbHighlight.vue
+++ b/src/components/highlights/NbHighlight.vue
@@ -17,7 +17,7 @@
             :y="box.top + bounds.offsetY"
             :height="box.height"
             :width="box.width">
-            <!-- <animate
+            <animate
                 v-if="showRecentActivityAnimation"
                 attributeType="XML"
                 attributeName="fill"
@@ -30,7 +30,7 @@
                 attributeName="fill"
                 values="#ffffff;#4a2270D9;#ffffff;#ffffff"
                 dur="2.0s"
-                repeatCount="indefinite"/> -->
+                repeatCount="indefinite"/>
         </rect>
 
     </g>

--- a/src/components/list/NotificationRow.vue
+++ b/src/components/list/NotificationRow.vue
@@ -7,14 +7,20 @@
       @mouseleave="onUnhoverNotification"
       @click="onClickNotification">
     <div class="flags" id="notification-row-flags"> 
-      <div v-if="notification.type === 'instructor'" class="icon-wrapper instructor" :style="flagsStyle">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'instructor'" class="icon-wrapper instructor" :style="flagsStyle"
+        v-tooltip="'Comment has instructor comment'"
+      >
+        i
+      </div>&nbsp;
+      <div v-if="notification.type === 'question'" class="icon-wrapper reply-request" :style="flagsStyle"
+        v-tooltip="'Comment has a reply request'"
+      >
+        <font-awesome-icon icon="question"></font-awesome-icon>&nbsp;
       </div>
-      <div v-if="notification.type === 'question'" class="icon-wrapper reply-request" :style="flagsStyle">
-        {{notification.readableType}}
-      </div>
-      <div v-if="notification.type === 'tag'" class="icon-wrapper tag" :style="flagsStyle">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'tag'" class="icon-wrapper tag" :style="flagsStyle"
+        v-tooltip="'Comment has your tag'"
+      >
+        <font-awesome-icon icon="user-tag"></font-awesome-icon>&nbsp;
       </div>
       <div v-if="notification.type === 'recent'" class="icon-wrapper recent" :style="flagsStyle"
         v-tooltip="'Recent comment'"

--- a/src/components/list/NotificationRow.vue
+++ b/src/components/list/NotificationRow.vue
@@ -6,7 +6,7 @@
       @mouseenter="onHoverNotification"
       @mouseleave="onUnhoverNotification"
       @click="onClickNotification">
-    <div class="flags">
+    <div class="flags" id="notification-row-flags"> 
       <div v-if="notification.type === 'instructor'" class="icon-wrapper instructor" :style="flagsStyle">
         {{notification.readableType}}
       </div>
@@ -16,15 +16,22 @@
       <div v-if="notification.type === 'tag'" class="icon-wrapper tag" :style="flagsStyle">
         {{notification.readableType}}
       </div>
-      <div v-if="notification.type === 'recent'" class="icon-wrapper recent" :style="flagsStyle">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'recent'" class="icon-wrapper recent" :style="flagsStyle"
+        v-tooltip="'Recent comment'"
+      >
+        <font-awesome-icon icon="history"></font-awesome-icon>&nbsp;
       </div>
-      <div :style="timeTextStyle">
-        {{timeString}}
+      <div v-if="notification.type === 'reply'" class="icon-wrapper reply" :style="flagsStyle"
+        v-tooltip="'Comment reply'"
+      >
+        <font-awesome-icon icon="reply"></font-awesome-icon>&nbsp;
       </div>
+      <span :style="textStyle">
+        {{authorName}}: {{ commentText }}
+      </span>
     </div>
-    <span :style="textStyle">
-      {{authorName}}: {{ commentText }}
+    <span :style="timeTextStyle">
+      {{timeString}}
     </span>
   </div>
 </template>

--- a/src/components/list/NotificationSidebarRow.vue
+++ b/src/components/list/NotificationSidebarRow.vue
@@ -7,14 +7,20 @@
       @mouseleave="onUnhoverNotification"
       @click="onClickNotification">
     <div class="flags">
-      <div v-if="notification.type === 'instructor'" class="icon-wrapper instructor">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'instructor'" class="icon-wrapper instructor"        
+        v-tooltip="'Comment has instructor comment'"
+      >
+        i
+      </div>&nbsp;
+      <div v-if="notification.type === 'question'" class="icon-wrapper reply-request"
+        v-tooltip="'Comment has a reply request'"
+      >
+        <font-awesome-icon icon="question"></font-awesome-icon>&nbsp;
       </div>
-      <div v-if="notification.type === 'question'" class="icon-wrapper reply-request">
-        {{notification.readableType}}
-      </div>
-      <div v-if="notification.type === 'tag'" class="icon-wrapper tag">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'tag'" class="icon-wrapper tag"
+        v-tooltip="'Comment has your tag'"
+      >
+        <font-awesome-icon icon="user-tag"></font-awesome-icon>&nbsp;
       </div>
       <div v-if="notification.type === 'recent'" class="icon-wrapper recent"
         v-tooltip="'Recent comment'"

--- a/src/components/list/NotificationSidebarRow.vue
+++ b/src/components/list/NotificationSidebarRow.vue
@@ -16,16 +16,23 @@
       <div v-if="notification.type === 'tag'" class="icon-wrapper tag">
         {{notification.readableType}}
       </div>
-      <div v-if="notification.type === 'recent'" class="icon-wrapper recent">
-        {{notification.readableType}}
+      <div v-if="notification.type === 'recent'" class="icon-wrapper recent"
+        v-tooltip="'Recent comment'"
+      >
+        <font-awesome-icon icon="history"></font-awesome-icon>&nbsp;
       </div>
-      <div :style="timeTextStyle">
-        {{timeString}}
+      <div v-if="notification.type === 'reply'" class="icon-wrapper reply"
+        v-tooltip="'Comment reply'"
+      >
+        <font-awesome-icon icon="reply"></font-awesome-icon>&nbsp;
+      </div>
+      <div :style="textStyle">
+        {{authorName}}: {{commentText}}
       </div>
     </div>
-    <div :style="textStyle">
-      {{authorName}}: {{commentText}}
-    </div>
+    <span :style="timeTextStyle">
+      {{timeString}}
+    </span>
 
 
   </div>

--- a/src/components/list/NotificationSidebarView.vue
+++ b/src/components/list/NotificationSidebarView.vue
@@ -10,6 +10,12 @@
             <font-awesome-icon icon="bell" class="icon" v-else>
             </font-awesome-icon>
         </span>
+        <span class="icons-left" v-tooltip="'Click to dock notifications into sidebar'"
+          @click="$emit('dock-draggable-notifications')"
+        >
+          <font-awesome-icon icon="clone" class="icon">
+          </font-awesome-icon>
+        </span>
       </div>
     </header>
     <div class="notification-table">

--- a/src/components/list/NotificationSidebarView.vue
+++ b/src/components/list/NotificationSidebarView.vue
@@ -14,9 +14,29 @@
     </header>
     <div class="notification-table">
       <notification-sidebar-row
-          v-for="(notification,index) in notifications" 
-          :notification="notifications[notifications.length-1-index]"
-          :key="notifications[notifications.length-1-index]"
+          v-for="(notification,index) in onlineNotifications" 
+          :notification="onlineNotifications[onlineNotifications.length-1-index]"
+          :key="onlineNotifications[onlineNotifications.length-1-index]"
+          :thread-selected="threadSelected"
+          :notification-selected="notificationSelected"
+          :threads-hovered="threadsHovered"
+          :user="user"
+          :active-class="activeClass"
+          @select-notification="onSelectNotification"
+          @hover-thread="onHoverNotification"
+          @unhover-thread="onUnhoverNotification">
+      </notification-sidebar-row>
+      <h4 id="olderNotificationHeading" v-if="offlineNotifications.length > 0">
+          <span id="olderNotificationSpanGray">
+            <font-awesome-icon icon="chevron-down"/>
+            Older Notifications
+            <font-awesome-icon icon="chevron-down"/>
+          </span>
+      </h4>
+      <notification-sidebar-row
+          v-for="(notification,index) in offlineNotifications" 
+          :notification="offlineNotifications[offlineNotifications.length-1-index]"
+          :key="offlineNotifications[offlineNotifications.length-1-index]"
           :thread-selected="threadSelected"
           :notification-selected="notificationSelected"
           :threads-hovered="threadsHovered"
@@ -104,6 +124,12 @@ export default {
     },
     numberUnseen: function () {
         return this.notifications.filter(n => n.unseen).length
+    },
+    offlineNotifications: function () {
+      return this.notifications.filter(n => n.isOfflineNotification)
+    },
+    onlineNotifications: function () {
+      return this.notifications.filter(n => !n.isOfflineNotification)
     }
   },
   methods: {

--- a/src/components/list/NotificationView.vue
+++ b/src/components/list/NotificationView.vue
@@ -35,9 +35,29 @@
       </div>
       <div class="notification-table">
         <notification-row
-            v-for="(notification,index) in notifications" 
-            :notification="notifications[notifications.length-1-index]"
-            :key="notifications[notifications.length-1-index]"
+            v-for="(notification,index) in onlineNotifications" 
+            :notification="onlineNotifications[onlineNotifications.length-1-index]"
+            :key="onlineNotifications[onlineNotifications.length-1-index]"
+            :thread-selected="threadSelected"
+            :notification-selected="notificationSelected"
+            :threads-hovered="threadsHovered"
+            :activeClass="activeClass"
+            :user="user"
+            @select-notification="onSelectNotification"
+            @hover-thread="onHoverNotification"
+            @unhover-thread="onUnhoverNotification">
+        </notification-row>
+        <h4 id="olderNotificationHeading" v-if="offlineNotifications.length > 0">
+          <span id="olderNotificationSpanWhite">
+            <font-awesome-icon icon="chevron-down"/>
+            Older Notifications
+            <font-awesome-icon icon="chevron-down"/>
+          </span>
+        </h4>
+        <notification-row
+            v-for="(notification,index) in offlineNotifications" 
+            :notification="offlineNotifications[offlineNotifications.length-1-index]"
+            :key="offlineNotifications[offlineNotifications.length-1-index]"
             :thread-selected="threadSelected"
             :notification-selected="notificationSelected"
             :threads-hovered="threadsHovered"
@@ -134,6 +154,12 @@ export default {
     },
     numberUnseen: function () {
         return this.notifications.filter(n => n.unseen).length
+    },
+    offlineNotifications: function () {
+      return this.notifications.filter(n => n.isOfflineNotification)
+    },
+    onlineNotifications: function () {
+      return this.notifications.filter(n => !n.isOfflineNotification)
     }
   },
   methods: {

--- a/src/components/list/NotificationView.vue
+++ b/src/components/list/NotificationView.vue
@@ -14,15 +14,6 @@
         <span class="count">
           {{ totalLabel }}
         </span>
-        <!-- <div class="icons-left-parent">
-          <span class="icons-left"
-            v-if="!draggableNotificationsOpened"
-            v-tooltip="'Open in separate popup'"
-            @click="onOpenDraggableNotifications">
-            <font-awesome-icon icon="envelope-open" class="icon">
-            </font-awesome-icon>          
-          </span>        
-        </div> -->
         <div class="icons-left">
           <span v-tooltip="notificationsMuted ? 'Click to unmute notifications' : 'Click to mute notifications'"
             @click="toggleMute">
@@ -30,7 +21,19 @@
             </font-awesome-icon>
             <font-awesome-icon icon="bell" class="icon" v-else>
             </font-awesome-icon>
-          </span>        
+          </span>   
+          <span v-tooltip="'Click to open draggable notifications window'"
+            @click="$emit('undock-draggable-notifications')"
+          >
+            <font-awesome-icon icon="clone" class="icon">
+            </font-awesome-icon>
+          </span>  
+          <span v-tooltip="'Click to close sidebar notifications window'"
+            @click="$emit('close-sidebar-notifications')"
+          >
+            <font-awesome-icon icon="window-close" class="icon">
+            </font-awesome-icon>          
+          </span>     
         </div>
       </div>
       <div class="notification-table">
@@ -177,9 +180,6 @@ export default {
     },
     toggleMute: function () {
       this.$emit('toggle-mute-notifications')
-    },
-    onOpenDraggableNotifications: function () {
-      this.$emit('open-draggable-notifications')
     }
   },
   components: {

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -606,12 +606,12 @@ class NbComment {
     return null
   }
 
-  hasMyAuthorReplies (myAuthorId) { // if any comment in this thread is unseen & replying to a thread by the authorId
+  getMyAuthorReplies (myAuthorId) { // if any comment in this thread is unseen & replying to a thread by the authorId
     if (!this.seenByMe && this.parent !== null && this.parent.author === myAuthorId) {
       return this
     }
     for (let child of this.children) {
-      let res = child.hasMyAuthorReplies(myAuthorId) 
+      let res = child.getMyAuthorReplies(myAuthorId) 
       if (res != null) {
         return res
       }

--- a/src/models/nbcomment.js
+++ b/src/models/nbcomment.js
@@ -606,6 +606,19 @@ class NbComment {
     return null
   }
 
+  hasMyAuthorReplies (myAuthorId) { // if any comment in this thread is unseen & replying to a thread by the authorId
+    if (!this.seenByMe && this.parent !== null && this.parent.author === myAuthorId) {
+      return this
+    }
+    for (let child of this.children) {
+      let res = child.hasMyAuthorReplies(myAuthorId) 
+      if (res != null) {
+        return res
+      }
+    }
+    return null 
+  }
+
   /**
    * Mark this comment and all its descendants as seen by the current user.
    */

--- a/src/models/nbnotification.js
+++ b/src/models/nbnotification.js
@@ -8,13 +8,13 @@ class NbNotification {
         this.trigger = 'NONE'
         // this.trigger is used to tell the spotlight logs what type of notification the user clicked on
         // ('NONE', 'INSTRUCTOR_COMMENTED', 'REPLY_REQUESTED', 'USER_TAGGED', 'USER_SAW_RECENT_ACTIVITY')
-        let triggerMap = {"tag": 'USER_TAGGED', "instructor": 'INSTRUCTOR_COMMENTED', "question": 'REPLY_REQUESTED', "recent": 'USER_SAW_RECENT_ACTIVITY'}
+        let triggerMap = {"tag": 'USER_TAGGED', "instructor": 'INSTRUCTOR_COMMENTED', "question": 'REPLY_REQUESTED', "recent": 'USER_SAW_RECENT_ACTIVITY', "reply": "USER_COMMENT_REPLIED_TO"}
         if (this.type in triggerMap) {
             this.trigger = triggerMap[this.type]
         }
 
         this.readableType = ''
-        let readableTypeMap = {"tag": "you've been tagged", "instructor": "instructor comment", "question": "reply requested", "recent": "recent comment nearby"}
+        let readableTypeMap = {"tag": "you've been tagged", "instructor": "instructor comment", "question": "reply requested", "recent": "recent comment nearby", "reply": "comment reply"}
         if (this.type in readableTypeMap) {
             this.readableType = readableTypeMap[this.type]
         }

--- a/src/models/nbnotification.js
+++ b/src/models/nbnotification.js
@@ -1,10 +1,11 @@
 class NbNotification {
-    constructor (comment, type, triggerPopup=false, specificAnnotation=null){
+    constructor (comment, type, triggerPopup=false, specificAnnotation=null, isOfflineNotification=false){
         this.comment = comment 
         this.unseen = true
         this.type = type // "question", "instructor", "recent", "tag"
         this.triggerPopup = triggerPopup
         this.specificAnnotation = specificAnnotation
+        this.isOfflineNotification = isOfflineNotification
         this.trigger = 'NONE'
         // this.trigger is used to tell the spotlight logs what type of notification the user clicked on
         // ('NONE', 'INSTRUCTOR_COMMENTED', 'REPLY_REQUESTED', 'USER_TAGGED', 'USER_SAW_RECENT_ACTIVITY')


### PR DESCRIPTION
- Use icons to represent notifications for reply requests, instructor comments, tag comments, and recent/blinking comments
- Show recent notifications for comments posted before user's current viewport
- Be able to change location between sidebar and pop-up notification
- Make read notifications no longer purple
- Add a section for older notifications

helen-nb URL: https://helen-nb.csail.mit.edu/nb_viewer.html?id=d2607a62366cf925256fcacca13c77dd

![image](https://user-images.githubusercontent.com/8744689/126602395-2a09b6fd-591b-4aec-8658-983445f5b071.png)
