### PR TITLE
Add full time to comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,19 +44,20 @@
     "express": "^4.17.0",
     "html-to-text": "^5.1.1",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.34",
     "quill-mention": "^2.1.1",
     "socket.io": "^3.0.5",
     "socket.io-client": "^3.0.5",
     "v-tooltip": "^2.0.1",
     "vue": "^2.6.10",
-    "vue-cli": "^2.9.6",
     "vue-avatar-component": "^1.3.1",
+    "vue-cli": "^2.9.6",
     "vue-draggable-resizable": "^2.3.0",
     "vue-jwt-decode": "^0.1.0",
     "vue-notification": "^1.3.20",
     "vue-quill": "^1.5.1",
     "vue-spinners": "^1.0.2",
-    "webpack-dev-server": "^3.11.2",
-    "vue-sweetalert2": "^4.2.0"
+    "vue-sweetalert2": "^4.2.0",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/public/style/plugin.css
+++ b/public/style/plugin.css
@@ -608,6 +608,7 @@
 #nb-app .nb-sidebar .thread-view .thread-row .header .timestamp {
   font-size: 13px;
   color: #444;
+  cursor: default;
 }
 #nb-app .nb-sidebar .thread-view .thread-row .header .options {
   position: absolute;

--- a/src/components/thread/ThreadComment.vue
+++ b/src/components/thread/ThreadComment.vue
@@ -8,7 +8,7 @@
                     </div>
                     <b>{{ authorName }}</b>{{ comment.author === me.id ? " (me)" : "" }}
                 </span>
-                <span class="timestamp">{{ timeString }}</span>
+                <span v-tooltip="timeFull" class="timestamp">{{ timeString }}</span>
                 <div class="options">
                     <span
                         class="bookmark"
@@ -132,7 +132,7 @@
 
 <script>
 import Vue from 'vue'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import { CommentAnonymity } from '../../models/enums.js'
 import { BootstrapVueIcons } from 'bootstrap-vue'
 import 'bootstrap-vue/dist/bootstrap-vue-icons.min.css'
@@ -245,6 +245,9 @@ export default {
         },
         timeString: function () {
             return moment(this.comment.timestamp).fromNow()
+        },
+        timeFull: function () {
+            return moment(this.comment.timestamp).tz(moment.tz.guess()).format("dddd, MMMM Do YYYY, h:mm:ss a (z)")
         },
         firstComment: function () {
             return !this.comment.parent


### PR DESCRIPTION
Show exact timestamp for the comment when hovering over time. 
![image](https://user-images.githubusercontent.com/22763091/152896144-bec65c50-8f4e-4366-a2f1-58629b8cd2f2.png)
 
