### PR TITLE
Fix mistake in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Installation
 ```
-git clone https://github.com/alisaono/nbdemo.git
-cd nbdemo
+git clone https://github.com/haystack/nbclient.git
+cd nbclient
 npm install
 npm install -g webpack
 ```
@@ -17,7 +17,7 @@ npm install -g webpack
 - Exception is the CSS files which are under `public/style`
 - To compile the JS/Vue source code:
 ```
-cd nbdemo
+cd nbclient
 webpack
 ```
 - You'll find the compiled code (`bundle.js`) under `public/js`
@@ -27,7 +27,7 @@ webpack
 ### Hosting files locally
 You can host the plugin files locally, which is useful for embedding and testing them locally. To do so:
 ```
-cd nbdemo
+cd nbclient
 npm run start
 ```
 You will then find the files hosted at `localhost:3001` (e.g. `localhost:3001/js/bundle.js`)
@@ -37,7 +37,7 @@ Note: Since we're using a self generated certificate for development, the browse
 ### Code documentation
 To see a nice webpage version of the in-file code documentation as, do:
 ```
-cd nbdemo
+cd nbclient
 ./node_modules/.bin/jsdoc -r src/ -c jsdoc.json
 ```
 You will then find `out/index.html` which you can view in your browser.


### PR DESCRIPTION
The clone link was wrong. It must have had an old one. Also, the name of the repo is nbclient, not nbdemo.